### PR TITLE
fix Google Play Store

### DIFF
--- a/ruleset/GooglePlayStoreFix.list
+++ b/ruleset/GooglePlayStoreFix.list
@@ -1,1 +1,3 @@
 DOMAIN-SUFFIX,services.googleapis.cn
+DOMAIN-SUFFIX,xn–ngstr-lra8j.com
+DOMAIN-SUFFIX,xn–ngstr-cn-8za9o.com


### PR DESCRIPTION
修复 google商店，
以下三个域名必须同时走直连 或者走代理 否则会一直等待中