### PR TITLE
fix: 消除「前置代理」组在 dialer-proxy 场景下的潜在循环引用

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -422,10 +422,12 @@ function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
     );
 
     /**
-     * 大多数策略组的通用候选列表：以"选择代理"为首选，再跟各国家组、低倍率、手动、直连。
+     * 大多数策略组的通用候选列表：以"选择代理"为首选，再跟落地节点（可选）、各国家组、低倍率、手动、直连。
+     * 将"落地节点"前置，方便 AI / 静态资源 等功能组直接下钻选择具体落地节点，无需绕道"手动选择"。
      */
     const defaultProxies = buildList(
         PROXY_GROUPS.SELECT,
+        landing && PROXY_GROUPS.LANDING,
         countryGroupNames,
         lowCost && PROXY_GROUPS.LOW_COST,
         PROXY_GROUPS.MANUAL,
@@ -621,6 +623,7 @@ function buildProxyGroups({
     countryProxyGroups,
     lowCostNodes,
     landingNodes,
+    nonLandingProxyNames,
     defaultProxies,
     defaultProxiesDirect,
     defaultSelector,
@@ -633,17 +636,6 @@ function buildProxyGroups({
     const hasTW = countries.includes("台湾");
     const hasHK = countries.includes("香港");
     const hasUS = countries.includes("美国");
-
-    /**
-     * "前置代理"组的候选列表：从 `defaultSelector` 中移除"落地节点"和"故障转移"，
-     * 避免前置代理与落地节点形成循环引用，以及与故障转移组相互嵌套。
-     * 仅在 `landing=true` 时使用；否则置为空数组。
-     */
-    const frontProxySelector = landing
-        ? defaultSelector.filter(
-              (name) => name !== PROXY_GROUPS.LANDING && name !== PROXY_GROUPS.FALLBACK
-          )
-        : [];
 
     return [
         {
@@ -664,17 +656,14 @@ function buildProxyGroups({
                   icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Area.png`,
                   type: "select",
                   /**
-                   * regex 模式：`include-all` 拉取所有节点，`exclude-filter` 排除落地节点，
-                   * 同时在 `proxies` 里附加手动指定的候选组名列表（各国家组等）。
-                   * 枚举模式：直接列出候选组名（落地节点已在构建 `frontProxySelector` 时过滤）。
+                   * 用作落地节点 `dialer-proxy` 目标的中转组，必须避免任何可能
+                   * 在 Stash 静态 loop 检测中回指落地节点的引用，因此：
+                   *   - 不使用 `include-all`（防止展开后含落地节点）
+                   *   - 不引用任何组（手动选择 / 自动选择 / 国家组等均含 include-all，规避一切风险）
+                   *   - 由脚本在生成时枚举所有非落地节点名，形成扁平列表
+                   * 末尾保留 `DIRECT` 作为"临时绕过中转"的逃生出口。
                    */
-                  ...(regexFilter
-                      ? {
-                            "include-all": true,
-                            "exclude-filter": LANDING_PATTERN,
-                            proxies: frontProxySelector,
-                        }
-                      : { proxies: frontProxySelector }),
+                  proxies: [...nonLandingProxyNames, "DIRECT"],
               }
             : null,
         landing
@@ -868,6 +857,16 @@ function main(config) {
     const countries = stripNodeSuffix(countryGroupNames);
 
     /**
+     * 提取所有非落地节点名，供"前置代理"组作为 `dialer-proxy` 目标使用。
+     * 在脚本层枚举而非运行时 include-all，以彻底规避 Stash 的静态 loop 检测。
+     */
+    const nonLandingProxyNames = landing
+        ? (resultConfig.proxies || [])
+              .map((proxy) => proxy.name)
+              .filter((name) => name && !LANDING_REGEX.test(name))
+        : [];
+
+    /**
      * 构建各类通用候选列表，供后续策略组复用。
      */
     const { defaultProxies, defaultProxiesDirect, defaultSelector, defaultFallback } =
@@ -893,6 +892,7 @@ function main(config) {
         countryProxyGroups,
         lowCostNodes,
         landingNodes,
+        nonLandingProxyNames,
         defaultProxies,
         defaultProxiesDirect,
         defaultSelector,


### PR DESCRIPTION
## 问题

README 建议链式代理用法中，为落地节点配置 `dialer-proxy: "前置代理"`：

```yaml
proxies:
  - name: "美国家宽落地"
    type: ss
    server: ...
    dialer-proxy: "前置代理"
```

在这种配置下，当前生成的 `前置代理` 组结构存在循环引用：`前置代理.proxies` 里包含 `手动选择` 和 `自动选择`，而：

- `手动选择` 使用 `include-all: true`，展开后包含所有节点（含该落地节点）
- `自动选择.proxies` 来自 `defaultFallback`，也包含 `手动选择`

`regex` 模式下 `前置代理` 自身的 `exclude-filter: LANDING_PATTERN` 不会作用到通过 `手动选择` 间接展开进来的节点上。实际闭包路径：

```
前置代理 → 手动选择 (include-all) → 落地节点 → dialer-proxy: 前置代理 → ...
```

Mihomo 对这种结构比较宽容、运行时能跑通；但配置上确实是循环引用，严格解析的内核（比如 Stash）会直接报 loop 拒绝加载。

## 改动

**1. `前置代理` 改为扁平节点名单**

`main()` 扫描 `config.proxies`，过滤掉匹配 `LANDING_REGEX` 的节点，把剩下的节点名直接写入 `前置代理.proxies`。不使用 `include-all`，也不引用任何策略组（国家组在 `regex` 模式下同样是 `include-all + filter`，理论上也会有相同风险，一并避开）。末尾保留 `DIRECT` 作为"临时绕过中转"的出口。

这样 `前置代理` 的候选只含具体的非落地节点，结构上不可能再形成回指。

**2. `defaultProxies` 加入 `落地节点`**

`landing=true` 时把 `落地节点` 放到 `defaultProxies` 第二位（仅次于 `选择代理`）。`AI服务 / 静态资源 / Apple / Google / ...` 这些基于 `defaultProxies` 的功能组可以直接下钻选到落地节点，不必绕 `手动选择`。

国内服务使用的 `defaultProxiesDirect` 不变。

如果这个 UX 改动不适合一起提，可以只保留第 1 点，拆成两个 PR。

## 代价

`前置代理` 组的 YAML 长度从几个组名变成所有非落地节点名，随机场节点数线性增长。作为低频切换的 `select` 组，代价可以接受。

## 测试

- `npm run lint` / `npm run format:check` 通过
- `npm run generate` 重新生成 `yamls/`，抽查 `landing-1` 的文件：
  - `前置代理` 为扁平节点列表 + `DIRECT`，无 `include-all`、无组引用
  - 功能组候选列表里出现 `落地节点`
- 实机验证链式代理工作正常

（`yamls/` 未纳入本 PR，按仓库惯例由合并后的 CI 重新生成。）
