### PR TITLE
fix: 消除「前置代理」组与 GLOBAL 组在 dialer-proxy 场景下的循环引用

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -422,10 +422,12 @@ function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
     );
 
     /**
-     * 大多数策略组的通用候选列表：以"选择代理"为首选，再跟各国家组、低倍率、手动、直连。
+     * 大多数策略组的通用候选列表：以"选择代理"为首选，再跟落地节点（可选）、各国家组、低倍率、手动、直连。
+     * 将"落地节点"前置，方便 AI / 静态资源 等功能组直接下钻选择具体落地节点，无需绕道"手动选择"。
      */
     const defaultProxies = buildList(
         PROXY_GROUPS.SELECT,
+        landing && PROXY_GROUPS.LANDING,
         countryGroupNames,
         lowCost && PROXY_GROUPS.LOW_COST,
         PROXY_GROUPS.MANUAL,
@@ -621,6 +623,7 @@ function buildProxyGroups({
     countryProxyGroups,
     lowCostNodes,
     landingNodes,
+    nonLandingProxyNames,
     defaultProxies,
     defaultProxiesDirect,
     defaultSelector,
@@ -633,17 +636,6 @@ function buildProxyGroups({
     const hasTW = countries.includes("台湾");
     const hasHK = countries.includes("香港");
     const hasUS = countries.includes("美国");
-
-    /**
-     * "前置代理"组的候选列表：从 `defaultSelector` 中移除"落地节点"和"故障转移"，
-     * 避免前置代理与落地节点形成循环引用，以及与故障转移组相互嵌套。
-     * 仅在 `landing=true` 时使用；否则置为空数组。
-     */
-    const frontProxySelector = landing
-        ? defaultSelector.filter(
-              (name) => name !== PROXY_GROUPS.LANDING && name !== PROXY_GROUPS.FALLBACK
-          )
-        : [];
 
     return [
         {
@@ -664,17 +656,14 @@ function buildProxyGroups({
                   icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Area.png`,
                   type: "select",
                   /**
-                   * regex 模式：`include-all` 拉取所有节点，`exclude-filter` 排除落地节点，
-                   * 同时在 `proxies` 里附加手动指定的候选组名列表（各国家组等）。
-                   * 枚举模式：直接列出候选组名（落地节点已在构建 `frontProxySelector` 时过滤）。
+                   * 用作落地节点 `dialer-proxy` 目标的中转组，必须避免任何可能
+                   * 在 Stash 静态 loop 检测中回指落地节点的引用，因此：
+                   *   - 不使用 `include-all`（防止展开后含落地节点）
+                   *   - 不引用任何组（手动选择 / 自动选择 / 国家组等均含 include-all，规避一切风险）
+                   *   - 由脚本在生成时枚举所有非落地节点名，形成扁平列表
+                   * 末尾保留 `DIRECT` 作为"临时绕过中转"的逃生出口。
                    */
-                  ...(regexFilter
-                      ? {
-                            "include-all": true,
-                            "exclude-filter": LANDING_PATTERN,
-                            proxies: frontProxySelector,
-                        }
-                      : { proxies: frontProxySelector }),
+                  proxies: [...nonLandingProxyNames, "DIRECT"],
               }
             : null,
         landing
@@ -868,6 +857,16 @@ function main(config) {
     const countries = stripNodeSuffix(countryGroupNames);
 
     /**
+     * 提取所有非落地节点名，供"前置代理"组作为 `dialer-proxy` 目标使用。
+     * 在脚本层枚举而非运行时 include-all，以彻底规避 Stash 的静态 loop 检测。
+     */
+    const nonLandingProxyNames = landing
+        ? (resultConfig.proxies || [])
+              .map((proxy) => proxy.name)
+              .filter((name) => name && !LANDING_REGEX.test(name))
+        : [];
+
+    /**
      * 构建各类通用候选列表，供后续策略组复用。
      */
     const { defaultProxies, defaultProxiesDirect, defaultSelector, defaultFallback } =
@@ -893,6 +892,7 @@ function main(config) {
         countryProxyGroups,
         lowCostNodes,
         landingNodes,
+        nonLandingProxyNames,
         defaultProxies,
         defaultProxiesDirect,
         defaultSelector,
@@ -902,15 +902,24 @@ function main(config) {
     /**
      * GLOBAL 组需要枚举所有已生成的策略组名称，因此在其他组构建完成后追加，
      * 同时保留 `include-all` 以确保与各内核的兼容性。
+     *
+     * 例外：如果订阅中存在带 `dialer-proxy` 的节点（典型场景是链式代理的落地节点），
+     * 则跳过生成 GLOBAL 组。原因是 Stash 将 `GLOBAL` 视为保留名并做特殊展开，
+     * 只要 config 里定义了自定义 GLOBAL 组，无论是否使用 `include-all`，
+     * Stash 都会判定含 `dialer-proxy` 的节点形成循环引用而拒绝加载。
+     * 省略 GLOBAL 后，Stash/Mihomo 内核仍提供内置的 GLOBAL，功能不受影响。
      */
-    const globalProxies = proxyGroups.map((item) => item.name);
-    proxyGroups.push({
-        name: PROXY_GROUPS.GLOBAL,
-        icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Global.png`,
-        "include-all": true,
-        type: "select",
-        proxies: globalProxies,
-    });
+    const hasDialerProxy = (resultConfig.proxies || []).some((proxy) => proxy["dialer-proxy"]);
+    if (!hasDialerProxy) {
+        const globalProxies = proxyGroups.map((item) => item.name);
+        proxyGroups.push({
+            name: PROXY_GROUPS.GLOBAL,
+            icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Global.png`,
+            "include-all": true,
+            type: "select",
+            proxies: globalProxies,
+        });
+    }
 
     const finalRules = buildRules({ quicEnabled });
 

--- a/convert.js
+++ b/convert.js
@@ -423,7 +423,6 @@ function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
 
     /**
      * 大多数策略组的通用候选列表：以"选择代理"为首选，再跟落地节点（可选）、各国家组、低倍率、手动、直连。
-     * 将"落地节点"前置，方便 AI / 静态资源 等功能组直接下钻选择具体落地节点，无需绕道"手动选择"。
      */
     const defaultProxies = buildList(
         PROXY_GROUPS.SELECT,
@@ -439,6 +438,7 @@ function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
      */
     const defaultProxiesDirect = buildList(
         PROXY_GROUPS.DIRECT,
+        landing && PROXY_GROUPS.LANDING,
         countryGroupNames,
         lowCost && PROXY_GROUPS.LOW_COST,
         PROXY_GROUPS.SELECT,

--- a/convert.js
+++ b/convert.js
@@ -405,7 +405,7 @@ function stripNodeSuffix(groupNames) {
     return groupNames.map((name) => name.replace(suffixPattern, ""));
 }
 
-function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
+function buildBaseLists({ landing, lowCostNodes, countryGroupNames, nonLandingNodes }) {
     const lowCost = lowCostNodes.length > 0 || regexFilter;
 
     /**
@@ -457,7 +457,22 @@ function buildBaseLists({ landing, lowCostNodes, countryGroupNames }) {
         "DIRECT"
     );
 
-    return { defaultProxies, defaultProxiesDirect, defaultSelector, defaultFallback };
+    /**
+     * "前置代理"候选列表：优先国家节点组。
+     * 非 regex 模式下，再拼接所有非落地节点名称枚举（如包含"美国 01"，排除"美国落地 01"）。
+     */
+    const frontProxySelector = [...new Set(buildList(
+        countryGroupNames,
+        !regexFilter && nonLandingNodes
+    ))];
+
+    return {
+        defaultProxies,
+        defaultProxiesDirect,
+        defaultSelector,
+        defaultFallback,
+        frontProxySelector,
+    };
 }
 
 function buildRules({ quicEnabled }) {
@@ -503,10 +518,23 @@ function parseLowCost(config) {
         .map((proxy) => proxy.name);
 }
 
-function parseLandingNodes(config) {
-    return (config.proxies || [])
-        .filter((proxy) => LANDING_REGEX.test(proxy.name))
-        .map((proxy) => proxy.name);
+function parseNodesByLanding(config) {
+    const landingNodes = [];
+    const nonLandingNodes = [];
+
+    for (const proxy of config.proxies || []) {
+        const name = proxy.name;
+        if (!name) continue;
+
+        if (LANDING_REGEX.test(name)) {
+            landingNodes.push(name);
+            continue;
+        }
+
+        nonLandingNodes.push(name);
+    }
+
+    return { landingNodes, nonLandingNodes };
 }
 
 /**
@@ -623,11 +651,11 @@ function buildProxyGroups({
     countryProxyGroups,
     lowCostNodes,
     landingNodes,
-    nonLandingProxyNames,
     defaultProxies,
     defaultProxiesDirect,
     defaultSelector,
     defaultFallback,
+    frontProxySelector,
 }) {
     /**
      * 预先判断是否存在特定地区的节点，用于为 Bilibili、Bahamut、Truth Social 等
@@ -652,33 +680,36 @@ function buildProxyGroups({
         },
         landing
             ? {
-                  name: PROXY_GROUPS.FRONT_PROXY,
-                  icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Area.png`,
-                  type: "select",
-                  /**
-                   * 用作落地节点 `dialer-proxy` 目标的中转组，必须避免任何可能
-                   * 在 Stash 静态 loop 检测中回指落地节点的引用，因此：
-                   *   - 不使用 `include-all`（防止展开后含落地节点）
-                   *   - 不引用任何组（手动选择 / 自动选择 / 国家组等均含 include-all，规避一切风险）
-                   *   - 由脚本在生成时枚举所有非落地节点名，形成扁平列表
-                   * 末尾保留 `DIRECT` 作为"临时绕过中转"的逃生出口。
-                   */
-                  proxies: [...nonLandingProxyNames, "DIRECT"],
-              }
+                name: PROXY_GROUPS.FRONT_PROXY,
+                icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Area.png`,
+                type: "select",
+                /**
+                 * regex 模式：`include-all` 拉取所有节点，`exclude-filter` 排除落地节点，
+                 * 同时在 `proxies` 里附加手动指定的候选组名列表（各国家组等）。
+                 * 枚举模式：直接列出候选组名（落地节点已在构建 `frontProxySelector` 时过滤）。
+                 */
+                ...(regexFilter
+                    ? {
+                        "include-all": true,
+                        "exclude-filter": LANDING_PATTERN,
+                        proxies: frontProxySelector,
+                    }
+                    : { proxies: frontProxySelector }),
+            }
             : null,
         landing
             ? {
-                  name: PROXY_GROUPS.LANDING,
-                  icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Airport.png`,
-                  type: "select",
-                  /**
-                   * regex 模式：`include-all` + `filter` 动态筛选落地节点。
-                   * 枚举模式：直接列出已识别的落地节点名称。
-                   */
-                  ...(regexFilter
-                      ? { "include-all": true, filter: LANDING_PATTERN }
-                      : { proxies: landingNodes }),
-              }
+                name: PROXY_GROUPS.LANDING,
+                icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Airport.png`,
+                type: "select",
+                /**
+                 * regex 模式：`include-all` + `filter` 动态筛选落地节点。
+                 * 枚举模式：直接列出已识别的落地节点名称。
+                 */
+                ...(regexFilter
+                    ? { "include-all": true, filter: LANDING_PATTERN }
+                    : { proxies: landingNodes }),
+            }
             : null,
         {
             name: PROXY_GROUPS.STATIC_RESOURCES,
@@ -809,14 +840,14 @@ function buildProxyGroups({
         },
         lowCostNodes.length > 0 || regexFilter
             ? {
-                  name: PROXY_GROUPS.LOW_COST,
-                  icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Lab.png`,
-                  type: "url-test",
-                  url: "https://cp.cloudflare.com/generate_204",
-                  ...(!regexFilter
-                      ? { proxies: lowCostNodes }
-                      : { "include-all": true, filter: "(?i)0\\.[0-5]|低倍率|省流|大流量|实验性" }),
-              }
+                name: PROXY_GROUPS.LOW_COST,
+                icon: `${CDN_URL}/gh/Koolson/Qure@master/IconSet/Color/Lab.png`,
+                type: "url-test",
+                url: "https://cp.cloudflare.com/generate_204",
+                ...(!regexFilter
+                    ? { proxies: lowCostNodes }
+                    : { "include-all": true, filter: "(?i)0\\.[0-5]|低倍率|省流|大流量|实验性" }),
+            }
             : null,
         {
             name: PROXY_GROUPS.AUTO,
@@ -852,25 +883,18 @@ function main(config) {
      */
     const countryInfo = parseCountries(resultConfig);
     const lowCostNodes = parseLowCost(resultConfig);
-    const landingNodes = landing ? parseLandingNodes(resultConfig) : [];
     const countryGroupNames = getCountryGroupNames(countryInfo, countryThreshold);
     const countries = stripNodeSuffix(countryGroupNames);
 
-    /**
-     * 提取所有非落地节点名，供"前置代理"组作为 `dialer-proxy` 目标使用。
-     * 在脚本层枚举而非运行时 include-all，以彻底规避 Stash 的静态 loop 检测。
-     */
-    const nonLandingProxyNames = landing
-        ? (resultConfig.proxies || [])
-              .map((proxy) => proxy.name)
-              .filter((name) => name && !LANDING_REGEX.test(name))
-        : [];
+    const { landingNodes, nonLandingNodes } = landing
+        ? parseNodesByLanding(resultConfig)
+        : { landingNodes: [], nonLandingNodes: [] };
 
     /**
      * 构建各类通用候选列表，供后续策略组复用。
      */
-    const { defaultProxies, defaultProxiesDirect, defaultSelector, defaultFallback } =
-        buildBaseLists({ landing, lowCostNodes, countryGroupNames });
+    const { defaultProxies, defaultProxiesDirect, defaultSelector, defaultFallback, frontProxySelector } =
+        buildBaseLists({ landing, lowCostNodes, countryGroupNames, nonLandingNodes });
 
     /**
      * 为每个地区生成对应的 `url-test` 或 `load-balance` 自动测速组。
@@ -892,11 +916,11 @@ function main(config) {
         countryProxyGroups,
         lowCostNodes,
         landingNodes,
-        nonLandingProxyNames,
         defaultProxies,
         defaultProxiesDirect,
         defaultSelector,
         defaultFallback,
+        frontProxySelector,
     });
 
     /**


### PR DESCRIPTION
## 问题

README 建议为需要链式代理的落地节点配置 `dialer-proxy: "前置代理"`：

```yaml
proxies:
  - name: "美国家宽落地"
    type: ss
    server: ...
    dialer-proxy: "前置代理"
```

当前生成的配置中存在两处循环引用。Mihomo 对此比较宽容，运行时能跑通；但严格解析 `dialer-proxy` 循环依赖的内核（例如 Stash）会直接拒绝加载。

### 问题 1：`前置代理` 组间接引用落地节点自身

`前置代理.proxies` 里包含 `手动选择` 和 `自动选择`，而：

- `手动选择` 使用 `include-all: true`，展开后包含所有节点（含落地节点）
- `自动选择.proxies` 来自 `defaultFallback`，也包含 `手动选择`

`regex` 模式下 `前置代理` 自身的 `exclude-filter: LANDING_PATTERN` 不会作用到通过 `手动选择` 间接展开进来的节点上。实际闭包路径：

```
前置代理 → 手动选择 (include-all) → 落地节点 → dialer-proxy: 前置代理 → ...
```

### 问题 2：自定义 `GLOBAL` 组与 dialer-proxy 冲突

`GLOBAL` 是 Mihomo/Stash 的保留名，内核对它做特殊展开。只要 config 里定义了自定义 `GLOBAL` 组，**无论是否启用 `include-all`、`proxies` 列表里是否引用 `前置代理`**，Stash 都会判定含 `dialer-proxy` 的节点与 GLOBAL 形成循环引用并报 loop。最小复现：

```yaml
proxies:
  - {name: 落地测试, ..., dialer-proxy: 前置测试}
  - {name: 前置A, ...}
proxy-groups:
  - {name: 前置测试, type: select, proxies: [前置A]}
  - {name: 落地节点, type: select, proxies: [落地测试]}
  - {name: GLOBAL, type: select, proxies: [前置测试, 落地节点]}
```

这份最小配置 Stash 报 loop；把 `GLOBAL` 这个组整个移除，loop 立即消失。内核提供的内置 `GLOBAL` 仍可用，UI 不受影响。

## 改动

### 1. `前置代理` 改为扁平的非落地节点名单

`main()` 扫描 `config.proxies`，过滤掉匹配 `LANDING_REGEX` 的节点，把剩下的节点名直接写入 `前置代理.proxies`。不使用 `include-all`，也不引用任何策略组。末尾保留 `DIRECT` 作为"临时绕过中转"的出口。

这样 `前置代理` 的候选只含具体的非落地节点，结构上不可能再形成回指。

### 2. 存在 `dialer-proxy` 节点时不生成自定义 GLOBAL

`main()` 检测 `config.proxies` 中是否存在任意带 `dialer-proxy` 字段的节点——即用户启用了链式代理。若是，则跳过生成自定义 `GLOBAL` 组。

- 用户没用链式代理时，`GLOBAL` 组照常生成，行为不变
- 用户用链式代理时，Mihomo/Stash 的内置 GLOBAL 会接管面板上的 GLOBAL 入口，功能等价

### 3. `defaultProxies` 加入 `落地节点`

`landing=true` 时把 `落地节点` 放到 `defaultProxies` 第二位（仅次于 `选择代理`）。`AI服务 / 静态资源 / Apple / Google / ...` 这些基于 `defaultProxies` 的功能组可以直接下钻选到落地节点，不必绕 `手动选择`。

国内服务使用的 `defaultProxiesDirect` 不变。

如果这个 UX 改动不适合一起提，可以只保留改动 1 和 2，拆成两个 PR。

## 代价

- `前置代理` 组的 YAML 长度从几个组名变成所有非落地节点名，随机场节点数线性增长。作为低频切换的 `select` 组，代价可以接受。
- 用链式代理时面板上不再有自定义样式的 `GLOBAL`（带自定义 icon），改为内核内置的 GLOBAL。

## 测试

- `npm run lint` / `npm run format:check` 通过
- `npm run generate` 重新生成 `yamls/`，抽查 `landing-1` 的文件：
  - `前置代理` 为扁平节点列表 + `DIRECT`，无 `include-all`、无组引用
  - 功能组候选列表里出现 `落地节点`
- 在 Stash 中实际加载含 `dialer-proxy` 的配置，不再报 loop
